### PR TITLE
Update peer dependencies range format

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "ua-parser-js": "1.0.2"
   },
   "peerDependencies": {
-    "react": ">=16.8 - 17",
-    "react-dom": ">=16.8 - 17"
+    "react": "16.8 - 17",
+    "react-dom": "16.8 - 17"
   },
   "devDependencies": {
     "@types/jest": "27.4.1",


### PR DESCRIPTION
Hi! In a project I'm working on we started getting errors about dependencies not matching up after upgrading to npm 8. I found that this project defines peer dependencies for `react` and `react-dom` as `>=16.8 - 17`, but according to https://semver.npmjs.com/ it won't match anything.

I changed it to what _I think_ was the original intent but let me know if it's not what you meant.